### PR TITLE
Fix en message typos

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -130,10 +130,10 @@
 		"message": "Connection check in progress"
 	},
 	"option_connection_check_ok": {
-		"message": " Connection successful"
+		"message": "Connection successful"
 	},
 	"option_connection_check_error": {
-		"message": "Connection not successfully"
+		"message": "Connection failed"
 	},
 	"option_connection_check_update_available": {
 		"message": "Update available for PiHole"


### PR DESCRIPTION
Fixed typos in en locale (_locales/en/messages.json):
- line 133: " Connection successful" -> "Connection successful"
- line 136: "Connection not successfully" -> "Connection failed"